### PR TITLE
fix(kube): fix the wrong interruption in update

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -213,7 +213,7 @@ func (c *client) update(namespace string, updates []resources, options UpdateOpt
 		}
 		// Ignore empty patch.
 		if len(patch) == 2 && string(patch) == "{}" {
-			return nil
+			continue
 		}
 		_, err = client.Patch(accessor.GetName(), types.StrategicMergePatchType, patch)
 		if err != nil {


### PR DESCRIPTION
<!-- PR template; please answer the questions. -->

**What this PR does**
`client.update` returns early before finishing handling all modifications. It's a wrong behavior.
- fix(kube): fix the wrong interruption in update
