### PR TITLE
fix(release): remain pvc after deletion of release

### DIFF
--- a/pkg/kube/options.go
+++ b/pkg/kube/options.go
@@ -41,17 +41,18 @@ type UpdateOptions struct {
 	Filter DeletionFilter
 }
 
-// ApplyModifier gets current and desired objects, then checks the update
-// can be performed.
-type ApplyModifier func(current, desired runtime.Object) error
+// OwnerChecker checks if an object can be seemed as child.
+// If the checker returns true, then OwnerReferences would
+// be ignored.
+type OwnerChecker func(obj runtime.Object) bool
 
 // ApplyOptions is a  group options for applying resources
 type ApplyOptions struct {
 	// OwnerReferences enforces owners when create/update/
 	// delete resources in an update operation.
 	OwnerReferences []metav1.OwnerReference
-	// Modifier is used to modify updated resources.
-	Modifier ApplyModifier
+	// OwnerChecker checks
+	Checker OwnerChecker
 }
 
 // DeleteOptions is a  group options for deleting resources

--- a/pkg/release/apply.go
+++ b/pkg/release/apply.go
@@ -79,7 +79,7 @@ func (rc *releaseContext) applyRelease(backend storage.ReleaseStorage, release *
 	// Apply resources.
 	if err := rc.client.Apply(release.Namespace, manifests, kube.ApplyOptions{
 		OwnerReferences: referencesForRelease(release),
-		// Modifier:        rc.apply,
+		Checker:         rc.ignore,
 	}); err != nil {
 		glog.Infof("Failed to apply resources for release %s/%s: %v", release.Namespace, release.Name, err)
 		return recordError(backend, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:
- fix(release): remain pvc after deletion of release
Remove `OwnerReferences` from PVCs for kubenertes 1.8.


**Special notes for your reviewer**:
/assin zoumo
/kind bug

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Remove `OwnerReferences` from PVCs.
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
