### PR TITLE
[INSTBS-21] fix(upgrade): skip update if manifest is not changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin/
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 .vscode
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@
 ROOT := github.com/caicloud/rudder
 
 # Target binaries. You can build multiple binaries for a single project.
-TARGETS := controller release-cli
+TARGETS := controller
 
 # Container image prefix and suffix added to targets.
 # The final built images are:

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -45,7 +45,7 @@ type Client interface {
 	// Get gets the current object by resources.
 	Get(namespace string, resources []string, options GetOptions) ([]runtime.Object, error)
 	// Apply creates/updates all these resources.
-	Apply(namespace string, resources []string, options ApplyOptions) error
+	Apply(namespace string, newResources, oldResources []string, options ApplyOptions) error
 	// Create creates all these resources.
 	Create(namespace string, resources []string, options CreateOptions) error
 	// Update updates all resources.
@@ -126,17 +126,37 @@ func (c *client) Get(namespace string, resources []string, options GetOptions) (
 }
 
 // Apply creates/updates all these resources.
-func (c *client) Apply(namespace string, resources []string, options ApplyOptions) error {
-	objs, err := c.objectsByOrder(resources, InstallOrder)
+func (c *client) Apply(namespace string, newResources, oldResources []string, options ApplyOptions) error {
+	newObjects, err := c.objectsByOrder(newResources, InstallOrder)
 	if err != nil {
 		return err
 	}
-	for _, obj := range objs {
+	oldObjects, err := c.objectsByOrder(oldResources, InstallOrder)
+	if err != nil {
+		return err
+	}
+	for _, obj := range newObjects {
+
 		gvk := obj.GetObjectKind().GroupVersionKind()
 		accessor, err := c.codec.AccessorForObject(obj)
 		if err != nil {
 			return err
 		}
+
+		if namespace != "default" && namespace != "kube-system" {
+			skipped := false
+			for _, each := range oldObjects {
+				if reflect.DeepEqual(obj, each) {
+					skipped = true
+					break
+				}
+			}
+			if skipped {
+				glog.Infoln(gvk.Kind, namespace, accessor.GetName(), "same manifest, skip update")
+				continue
+			}
+		}
+
 		if options.OwnerReferences != nil &&
 			// options.Checker is used to check if the object is belong to current owner.
 			// If not, add owner references to obj.

--- a/pkg/release/apply.go
+++ b/pkg/release/apply.go
@@ -18,6 +18,7 @@ import (
 func (rc *releaseContext) applyRelease(backend storage.ReleaseStorage, release *releaseapi.Release) error {
 	// Deep copy release. Avoid modifying original release.
 	release = release.DeepCopy()
+	oldManifests := render.SplitManifest(release.Status.Manifest)
 
 	var manifests []string
 	if release.Spec.RollbackTo != nil {
@@ -122,7 +123,7 @@ func (rc *releaseContext) applyRelease(backend storage.ReleaseStorage, release *
 
 	}
 	// Apply resources.
-	if err := rc.client.Apply(release.Namespace, manifests, kube.ApplyOptions{
+	if err := rc.client.Apply(release.Namespace, manifests, oldManifests, kube.ApplyOptions{
 		OwnerReferences: referencesForRelease(release),
 		Checker:         rc.ignore,
 	}); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

星巴克需要将 k8s 从 1.12 升级到 1.14，由于 k8s 版本的升级，导致 dp/sts/ds/job 的 .Spec.Template 发生了变化（pod-template-hash 发生了变化），会重新创建 Pod，导致用户服务重启。
这个 PR 修正了这个问题，当 release 渲染出来的 manifest 未发生变化时，则不会去调用 update 接口，避免了 pod 重建。

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to https://jira.bytedance.com/browse/INSTBS-21
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @hezhizhen @whalecold @yelongyu 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
